### PR TITLE
test as a dev dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/Zfinix/username_gen
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
-dependencies:
+dev_dependencies:
   test: ^1.17.3
   
 


### PR DESCRIPTION
i noticed that the library, when used, pulls in a whole bunch of dependent libraries, even a webserver.